### PR TITLE
Mean rh

### DIFF
--- a/adb_graphics/datahandler/grib.py
+++ b/adb_graphics/datahandler/grib.py
@@ -129,10 +129,18 @@ class UPPData(specs.VarSpec):
 
         return values - self.values(name=variable2, level=level2)
     
-#    def field_mean(self, values, variable2, level2, variable3, level3, **kwargs) -> np.ndarray:
     def field_mean(self, values, variable, levels, **kwargs) -> np.ndarray:
 
-<<<<<<< Updated upstream
+        # pylint: disable=unused-argument
+
+        ''' Returns the mean of the values. '''
+
+        sum = values * 0.
+        for level in levels:
+            sum = sum + self.values(name=variable, level=level)
+            
+        return sum / len(levels)
+    
     def get_field(self, ncl_name):
 
         ''' Given an ncl_name, return the NioVariable object. '''
@@ -144,26 +152,6 @@ class UPPData(specs.VarSpec):
 
         return field
 
-=======
-        # pylint: disable=unused-argument
-
-        ''' Returns the mean of the values. '''
-
-#        return (values + self.values(name=variable2, level=level2) + self.values(name=variable3, level=level3)) / 3.
-        sum = values * 0.
-        print('levels = ',levels)
-        for level in levels:
-            print("variable = ",variable)
-#            print(values)
-            print("level = ",level)
-            print(self.values(name=variable, level=level))
-            sum = sum + self.values(name=variable, level=level)
-            
-        print("len(levels) = ",len(levels))    
-        
-        return sum / len(levels)
-    
->>>>>>> Stashed changes
     def get_level(self, field, level, spec):
 
         ''' Returns the value of the level to for a 3D array '''
@@ -179,6 +167,9 @@ class UPPData(specs.VarSpec):
         levs = self.ds[dim_name].values
 
         # Requested level
+        if level == 'mean':
+            lev = 0
+            return lev
         lev_val, _ = self.numeric_level(level=level)
 
         return int(np.argwhere(levs == lev_val))
@@ -270,7 +261,7 @@ class UPPData(specs.VarSpec):
 
         if index_match:
             lev_val = lev_val / 100. if lev_unit == 'cm' else lev_val
-            lev_val = lev_val * 100. if lev_unit in ['mb', 'mxmb', 'mbmn'] else lev_val
+            lev_val = lev_val * 100. if lev_unit in ['mb', 'mxmb'] else lev_val
             lev_val = lev_val * 1000. if lev_unit in ['km', 'mx', 'sr'] else lev_val
 
         return lev_val, lev_unit
@@ -469,20 +460,16 @@ class fieldData(UPPData):
         '''
 
         level = level if level else self.level
-        print('in values: level = ',level)
 
         vertical_index = kwargs.get('vertical_index')
 
         ncl_name = kwargs.get('ncl_name', '')
         ncl_name = ncl_name.format(fhr=self.fhr, grid=self.grid_suffix)
 
-        print('ncl_name = ',ncl_name)
         if name is None and not ncl_name:
-            print('leg 1')
             field = self.field
             spec = self.vspec
         else:
-            print('leg 2')
             spec = self.spec.get(name, {}).get(level, {})
             if not spec and name is not None:
                 raise errors.NoGraphicsDefinitionForVariable(name, level)
@@ -498,7 +485,6 @@ class fieldData(UPPData):
             vals = field[lev, :, :]
 
         transforms = spec.get('transform')
-        print('transforms = ',transforms)
         if transforms:
             vals = self.get_transform(transforms, vals)
 

--- a/adb_graphics/datahandler/grib.py
+++ b/adb_graphics/datahandler/grib.py
@@ -128,7 +128,11 @@ class UPPData(specs.VarSpec):
         ''' Subtracts the values from variable2 from self.field. '''
 
         return values - self.values(name=variable2, level=level2)
+    
+#    def field_mean(self, values, variable2, level2, variable3, level3, **kwargs) -> np.ndarray:
+    def field_mean(self, values, variable, levels, **kwargs) -> np.ndarray:
 
+<<<<<<< Updated upstream
     def get_field(self, ncl_name):
 
         ''' Given an ncl_name, return the NioVariable object. '''
@@ -140,6 +144,26 @@ class UPPData(specs.VarSpec):
 
         return field
 
+=======
+        # pylint: disable=unused-argument
+
+        ''' Returns the mean of the values. '''
+
+#        return (values + self.values(name=variable2, level=level2) + self.values(name=variable3, level=level3)) / 3.
+        sum = values * 0.
+        print('levels = ',levels)
+        for level in levels:
+            print("variable = ",variable)
+#            print(values)
+            print("level = ",level)
+            print(self.values(name=variable, level=level))
+            sum = sum + self.values(name=variable, level=level)
+            
+        print("len(levels) = ",len(levels))    
+        
+        return sum / len(levels)
+    
+>>>>>>> Stashed changes
     def get_level(self, field, level, spec):
 
         ''' Returns the value of the level to for a 3D array '''
@@ -246,7 +270,7 @@ class UPPData(specs.VarSpec):
 
         if index_match:
             lev_val = lev_val / 100. if lev_unit == 'cm' else lev_val
-            lev_val = lev_val * 100. if lev_unit in ['mb', 'mxmb'] else lev_val
+            lev_val = lev_val * 100. if lev_unit in ['mb', 'mxmb', 'mbmn'] else lev_val
             lev_val = lev_val * 1000. if lev_unit in ['km', 'mx', 'sr'] else lev_val
 
         return lev_val, lev_unit
@@ -445,16 +469,20 @@ class fieldData(UPPData):
         '''
 
         level = level if level else self.level
+        print('in values: level = ',level)
 
         vertical_index = kwargs.get('vertical_index')
 
         ncl_name = kwargs.get('ncl_name', '')
         ncl_name = ncl_name.format(fhr=self.fhr, grid=self.grid_suffix)
 
+        print('ncl_name = ',ncl_name)
         if name is None and not ncl_name:
+            print('leg 1')
             field = self.field
             spec = self.vspec
         else:
+            print('leg 2')
             spec = self.spec.get(name, {}).get(level, {})
             if not spec and name is not None:
                 raise errors.NoGraphicsDefinitionForVariable(name, level)
@@ -470,6 +498,7 @@ class fieldData(UPPData):
             vals = field[lev, :, :]
 
         transforms = spec.get('transform')
+        print('transforms = ',transforms)
         if transforms:
             vals = self.get_transform(transforms, vals)
 

--- a/adb_graphics/datahandler/grib.py
+++ b/adb_graphics/datahandler/grib.py
@@ -167,9 +167,6 @@ class UPPData(specs.VarSpec):
         levs = self.ds[dim_name].values
 
         # Requested level
-        if level == 'mean':
-            lev = 0
-            return lev
         lev_val, _ = self.numeric_level(level=level)
 
         return int(np.argwhere(levs == lev_val))

--- a/adb_graphics/datahandler/grib.py
+++ b/adb_graphics/datahandler/grib.py
@@ -135,7 +135,7 @@ class UPPData(specs.VarSpec):
 
         ''' Returns the mean of the values. '''
 
-        sum = values * 0.
+        sum = np.zeros_like(values)
         for level in levels:
             sum = sum + self.values(name=variable, level=level)
             

--- a/adb_graphics/datahandler/grib.py
+++ b/adb_graphics/datahandler/grib.py
@@ -128,19 +128,19 @@ class UPPData(specs.VarSpec):
         ''' Subtracts the values from variable2 from self.field. '''
 
         return values - self.values(name=variable2, level=level2)
-    
+
     def field_mean(self, values, variable, levels, **kwargs) -> np.ndarray:
 
         # pylint: disable=unused-argument
 
         ''' Returns the mean of the values. '''
 
-        sum = np.zeros_like(values)
+        fsum = np.zeros_like(values)
         for level in levels:
-            sum = sum + self.values(name=variable, level=level)
-            
-        return sum / len(levels)
-    
+            fsum = fsum + self.values(name=variable, level=level)
+
+        return fsum / len(levels)
+
     def get_field(self, ncl_name):
 
         ''' Given an ncl_name, return the NioVariable object. '''

--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -145,8 +145,8 @@ cape:
         linewidths: 0.6
     hatches:
       lpl_agl:
-        alpha: 0
-        hatches: ['///', '']
+        alpha: 0.3
+        hatches: ['', '///']
         levels: [50, 1000]
     ncl_name: CAPE_P0_2L108_{grid}
     ticks: 0
@@ -156,21 +156,37 @@ cape:
   mul: # Most Unstable Layer CAPE
     <<: *cape
     contours:
+      cape:
+        colors: white
+        levels: [1000, 100000]
+        linewidths: 1.2
+      lpl_agl:
+        colors: 'k'
+        levels: [50, 1000]
+        linewidths: 0.6
     hatches:
+      lpl_agl:
+        alpha: 0.3
+        hatches: ['', '///']
+        levels: [50, 1000]
     ncl_name: CAPE_P0_2L108_{grid}
     title: Most Unstable Layer CAPE
     vertical_index: 1
   mx90mb: # Lowest 90 mb Mixed Layer CAPE
     <<: *cape
     contours:
+      cape:
+        colors: white
+        levels: [1000, 100000]
+        linewidths: 1.2
       cin:
         colors: 'k'
         levels: [-1000, -50]
         linewidths: 0.6
     hatches:
       cin_mx90mb:
-        alpha: 0
-        hatches: ['///', '']
+        alpha: 0.3
+        hatches: ['', '///']
         levels: [-1000, -50]
     vertical_index: 0
     ncl_name: CAPE_P0_2L108_{grid}
@@ -184,8 +200,8 @@ cape:
         linewidths: 0.6
     hatches:
       cin_sfclt:
-        alpha: 0
-        hatches: ['///', '']
+        alpha: 0.3
+        hatches: ['', '///']
         levels: [-1000, -50]
     ncl_name: CAPE_P0_L1_{grid}
     title: Surface CAPE
@@ -221,6 +237,12 @@ ceilexp2: # Ceiling - experimental no.2
     <<: *ceil
     ncl_name: CEIL_P0_L2_{grid}
     title: Ceiling (exp-2)
+cfrzr: # Categorical Freezing Rain
+  sfc:
+    ncl_name: CFRZR_P0_L1_{grid}
+cicep: # Categorical Ice Pellets
+  sfc:
+    ncl_name: CFRZR_P0_L1_{grid}
 cin: # Surface Convective Inhibition
   mu:
     clevs: [-300, -200, -150, -100, -75, -50, -40, -30, -20, -10, -1]
@@ -289,6 +311,12 @@ cpofp: # Frozen Precipitation Percentage
     ticks: 0
     title: Frozen Precip Percentage
     unit: '%'
+crain: # Categorical Rain
+  sfc:
+    ncl_name: CRAIN_P0_L1_{grid}
+csnow: # Categorical Snow
+  sfc:
+    ncl_name: CSNOW_P0_L1_{grid}
 ctop: # Cloud top height
   ua:
     clevs: !!python/object/apply:numpy.arange [0, 61, 5]
@@ -611,6 +639,61 @@ ptmp: # Potential temperature
     ticks: 10
     unit: K
     wind: 10m
+ptyp: # Hourly total precipitation
+  sfc:
+    clevs: [0.002, 0.01, 0.05, 0.1, 0.25, 0.50, 0.75, 1.0, 2.0]
+    cmap: gist_ncar
+    colors: pcp_colors
+    contours:
+      crain_sfc:
+        colors: green
+        levels: [0, 1]
+        linewidths: 0.2
+      csnow_sfc:
+        colors: blue
+        levels: [0, 1]
+        linewidths: 0.2
+      cfrzr_sfc:
+        colors: purple
+        levels: [0, 1]
+        linewidths: 0.5
+      cicep_sfc:
+        colors: red
+        levels: [0, 1]
+        linewidths: 0.5
+    hatches:
+      # python causes an error using contourf with the
+      # option "extend='both'" for 3-char string colors
+      # ('red', 'tan', etc.), so leave in lists
+      crain_sfc:
+        colors: [green]
+        hatches: ['', '|||']
+        labels: Rain
+        levels: [0, 1]
+        linewidths: 0.1
+      csnow_sfc:
+        colors: [blue]
+        hatches: ['', '---']
+        labels: Snow
+        levels: [0, 1]
+        linewidths: 0.1
+      cfrzr_sfc:
+        colors: [purple]
+        hatches: ['', '///']
+        labels: Freezing Rain
+        levels: [0, 1]
+        linewidths: 0.2
+      cicep_sfc:
+        colors: [red]
+        hatches: ['', '\\\\']
+        labels: Ice Pellets
+        levels: [0, 1]
+        linewidths: 0.2
+    ncl_name: APCP_P8_L1_GLC0_acc1h
+    ticks: 0
+    title: 1 hr Total Precip, Precip Type
+    transform: conversions.kgm2_to_in
+    unit: in
 pwtr: # Precipitable water
   sfc:
     clevs: !!python/object/apply:numpy.arange [4, 81, 4]
@@ -646,8 +729,7 @@ rh: # Relative Humidity
         linewidths: 0.6
     hatches:
       pres_sfc:
-        alpha: 0
-        hatches: ['...', '']
+        hatches: ['', '...']
         levels: [0, 500]
   525mb:
     <<: *rh_ua
@@ -672,8 +754,7 @@ rh: # Relative Humidity
         linewidths: 0.6
     hatches:
       pres_sfc:
-        alpha: 0
-        hatches: ['...', '']
+        hatches: ['', '...']
         levels: [0, 700]
   725mb:
     <<: *rh_ua
@@ -694,13 +775,8 @@ rh: # Relative Humidity
         linewidths: 0.6
     hatches:
       pres_sfc:
-        alpha: 0
-        hatches: ['...', '']
+        hatches: ['', '...']
         levels: [0, 850]
-  pw: # RH wrt Precipitable Water
-    <<: *rh
-    ncl_name: RHPW_P0_L10_{grid}
-    title: Relative Humidity wrt Precipitable Water
   mean: # Mean RH 850mb to 500mb
     <<: *rh_ua
     title: Mean 850-500mb Relative Humidity
@@ -709,6 +785,10 @@ rh: # Relative Humidity
       kwargs:
         variable: rh
         levels: [500mb, 525mb, 550mb, 575mb, 600mb, 625mb, 650mb, 675mb, 700mb, 725mb, 750mb, 775mb, 800mb, 825mb, 850mb]
+  pw: # RH wrt Precipitable Water
+    <<: *rh
+    ncl_name: RHPW_P0_L10_{grid}
+    title: Relative Humidity wrt Precipitable Water
 rvil: # Radar-derived Vertically Integrated Liquid
   sfc: &vert_int_liq
     clevs: [0.05, 0.15, 0.76, 3.47, 6.92, 12, 31.6, 35, 40, 45, 50, 55, 60, 65, 70]
@@ -890,8 +970,7 @@ temp: # Temperature
         colors: grey
     hatches:
       pres_sfc:
-        alpha: 0
-        hatches: ['...', '']
+        hatches: ['', '...']
         levels: [0, 500]
     ncl_name:
       prs: TMP_P0_L100_{grid}
@@ -912,8 +991,7 @@ temp: # Temperature
         colors: grey
     hatches:
       pres_sfc:
-        alpha: 0
-        hatches: ['...', '']
+        hatches: ['', '...']
         levels: [0, 700]
     ncl_name:
       prs: TMP_P0_L100_{grid}
@@ -932,8 +1010,7 @@ temp: # Temperature
         linewidths: 0.6
     hatches:
       pres_sfc:
-        alpha: 0
-        hatches: ['...', '']
+        hatches: ['', '...']
         levels: [0, 850]
   925mb:
     <<: *ua_temp
@@ -945,8 +1022,7 @@ temp: # Temperature
         linewidths: 0.6
     hatches:
       pres_sfc:
-        alpha: 0
-        hatches: ['...', '']
+        hatches: ['', '...']
         levels: [0, 925]
   sfc:
     clevs: !!python/object/apply:numpy.arange [-60, 120, 10]

--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -701,7 +701,7 @@ rh: # Relative Humidity
     <<: *rh
     ncl_name: RHPW_P0_L10_{grid}
     title: Relative Humidity wrt Precipitable Water
-  700mbmn: # Mean RH 850mb to 500mb
+  mean: # Mean RH 850mb to 500mb
     <<: *rh_ua
     title: Mean 850-500mb Relative Humidity
     transform: 

--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -779,12 +779,13 @@ rh: # Relative Humidity
         levels: [0, 850]
   mean: # Mean RH 850mb to 500mb
     <<: *rh_ua
-    title: Mean 850-500mb Relative Humidity
+    title: Mean 850-500mb Relative Humidity, 700mb Wind
     transform: 
       funcs: field_mean
       kwargs:
         variable: rh
         levels: [500mb, 525mb, 550mb, 575mb, 600mb, 625mb, 650mb, 675mb, 700mb, 725mb, 750mb, 775mb, 800mb, 825mb, 850mb]
+    wind: 700mb
   pw: # RH wrt Precipitable Water
     <<: *rh
     ncl_name: RHPW_P0_L10_{grid}

--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -778,15 +778,16 @@ rh: # Relative Humidity
         hatches: ['', '...']
         levels: [0, 850]
   mean: # Mean RH 850mb to 500mb
-    <<: *rh_ua
-    title: Mean 850-500mb Relative Humidity, 700mb Wind
+    <<: *rh
+    print_units: false
+    title: Mean 850-500mb Relative Humidity (%, shaded), 700mb Wind (kt)
     transform: 
       funcs: field_mean
       kwargs:
         variable: rh
         levels: [500mb, 525mb, 550mb, 575mb, 600mb, 625mb, 650mb, 675mb, 700mb, 725mb, 750mb, 775mb, 800mb, 825mb, 850mb]
-    wind: 700mb
     vertical_index: 0 # Not used in mean computation, but is used to initialize new array for summing levels
+    wind: 700mb
   pw: # RH wrt Precipitable Water
     <<: *rh
     ncl_name: RHPW_P0_L10_{grid}

--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -649,6 +649,20 @@ rh: # Relative Humidity
         alpha: 0
         hatches: ['...', '']
         levels: [0, 500]
+  525mb:
+    <<: *rh_ua
+  550mb:
+    <<: *rh_ua
+  575mb:
+    <<: *rh_ua
+  600mb:
+    <<: *rh_ua
+  625mb:
+    <<: *rh_ua
+  650mb:
+    <<: *rh_ua
+  675mb:
+    <<: *rh_ua
   700mb:
     <<: *rh_ua
     contours:
@@ -661,6 +675,16 @@ rh: # Relative Humidity
         alpha: 0
         hatches: ['...', '']
         levels: [0, 700]
+  725mb:
+    <<: *rh_ua
+  750mb:
+    <<: *rh_ua
+  775mb:
+    <<: *rh_ua
+  800mb:
+    <<: *rh_ua
+  825mb:
+    <<: *rh_ua
   850mb:
     <<: *rh_ua
     contours:
@@ -677,6 +701,14 @@ rh: # Relative Humidity
     <<: *rh
     ncl_name: RHPW_P0_L10_{grid}
     title: Relative Humidity wrt Precipitable Water
+  700mbmn: # Mean RH 850mb to 500mb
+    <<: *rh_ua
+    title: Mean 850-500mb Relative Humidity
+    transform: 
+      funcs: field_mean
+      kwargs:
+        variable: rh
+        levels: [500mb, 525mb, 550mb, 575mb, 600mb, 625mb, 650mb, 675mb, 700mb, 725mb, 750mb, 775mb, 800mb, 825mb, 850mb]
 rvil: # Radar-derived Vertically Integrated Liquid
   sfc: &vert_int_liq
     clevs: [0.05, 0.15, 0.76, 3.47, 6.92, 12, 31.6, 35, 40, 45, 50, 55, 60, 65, 70]

--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -786,6 +786,7 @@ rh: # Relative Humidity
         variable: rh
         levels: [500mb, 525mb, 550mb, 575mb, 600mb, 625mb, 650mb, 675mb, 700mb, 725mb, 750mb, 775mb, 800mb, 825mb, 850mb]
     wind: 700mb
+    vertical_index: 0 # Not used in mean computation, but is used to initialize new array for summing levels
   pw: # RH wrt Precipitable Water
     <<: *rh
     ncl_name: RHPW_P0_L10_{grid}

--- a/adb_graphics/figures/maps.py
+++ b/adb_graphics/figures/maps.py
@@ -380,7 +380,7 @@ class DataMap():
         if self.hatch_fields:
             cf = self.hatch_fields[0]
             not_labeled.extend([h.short_name for h in self.hatch_fields])
-            if cf not in ['pres']:
+            if not any(list(set(cf.short_name).intersection(['pres']))):
                 title = cf.vspec.get('title', cf.field.long_name)
                 contoured.append(f'{title} ({cf.units}, hatched)')
 
@@ -403,7 +403,11 @@ class DataMap():
 
         # Two lines for shaded data (top), and contoured data (bottom)
         title = f.vspec.get('title', f.field.long_name)
-        plt.title(f"{title} ({f.units}, shaded)\n {contoured}",
+        if f.vspec.get('print_units', True):
+            units = f'({f.units}, shaded)'
+        else:
+            units = f''
+        plt.title(f"{title} {units}\n {contoured}",
                   loc='right',
                   fontsize=16,
                   )

--- a/image_lists/hrrr.yml
+++ b/image_lists/hrrr.yml
@@ -134,7 +134,7 @@ hourly:
     rh:
       - 2m
       - 850mb
-      - ua
+      - mean
     rhpw:
       - sfc
     rvil:

--- a/image_lists/hrrr_subset.yml
+++ b/image_lists/hrrr_subset.yml
@@ -83,6 +83,7 @@ hourly:
     rh:
       - 2m
       - 850mb
+      - mean
     rvil:
       - sfc
     shear:

--- a/image_lists/rap.yml
+++ b/image_lists/rap.yml
@@ -57,7 +57,7 @@ hourly:
     rh:
       - 2m
       - 850mb
-      - ua
+      - mean
     rhpw:
       - sfc
     rvil:

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -133,6 +133,7 @@ class TestDefaultSpecs():
             'hatches': self.is_a_contourf_dict,
             'labels': self.is_a_contourf_dict,
             'ncl_name': True,
+            'print_units': True,
             'ticks': self.is_number,
             'title': self.is_string,
             'transform': self.check_transform,

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -131,6 +131,7 @@ class TestDefaultSpecs():
             'colors': self.is_a_color,
             'contours': self.is_a_contour_dict,
             'hatches': self.is_a_contourf_dict,
+            'labels': self.is_a_contourf_dict,
             'ncl_name': True,
             'ticks': self.is_number,
             'title': self.is_string,
@@ -306,7 +307,7 @@ class TestDefaultSpecs():
         arguments. '''
 
         args = ['X', 'Y', 'Z', 'levels',
-                'corner_mask', 'colors', 'alpha', 'cmap', 'norm', 'vmin',
+                'corner_mask', 'colors', 'alpha', 'cmap', 'labels', 'norm', 'vmin',
                 'vmax', 'origin', 'extent', 'locator', 'extend', 'xunits',
                 'yunits', 'antialiased', 'nchunk', 'linewidths',
                 'hatches']


### PR DESCRIPTION
These are additions to produce the mean 850mb-500mb RH plot.  A new function, field_mean, was introduced in grib.py to compute the mean of any number of fields of the same type, defined in default_specs.py.  Here is an example with its NCL counterpart:

![image](https://user-images.githubusercontent.com/58485074/99713764-efe6b280-2a61-11eb-8ccb-b772f67fd3e3.png)
![image](https://user-images.githubusercontent.com/58485074/99713845-0c82ea80-2a62-11eb-826d-f870c67bbd57.png)
