### PR TITLE
Adds an image list for RTMA

### DIFF
--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -275,11 +275,6 @@ cloudcover:
     <<: *cld_cover
     ncl_name: TCDC_P0_L10_{grid}
     title: Total Cloud Cover
-cref: # Composite reflectivity
-  sfc:
-    <<: *refl
-    ncl_name: REFC_P0_L10_{grid}
-    title: Composite Reflectivity
 cpofp: # Frozen Precipitation Percentage
   sfc:
     clevs: [-0.1, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100]
@@ -289,6 +284,11 @@ cpofp: # Frozen Precipitation Percentage
     ticks: 0
     title: Frozen Precip Percentage
     unit: '%'
+cref: # Composite reflectivity
+  sfc:
+    <<: *refl
+    ncl_name: REFC_P0_L10_{grid}
+    title: Composite Reflectivity
 ctop: # Cloud top height
   ua:
     clevs: !!python/object/apply:numpy.arange [0, 61, 5]
@@ -1029,11 +1029,6 @@ vddsf: # Incoming Diffuse Radiation
     <<: *incoming_radiation
     ncl_name: VDDSF_P0_L1_{grid}
     title: Incoming Diffuse Radiation
-vil: # Vertically Integrated Liquid
-  sfc:
-    <<: *vert_int_liq
-    ncl_name: VAR_0_16_201_P0_L10_{grid}
-    title: Vertically Integrated Liquid
 vig: # Vertically-integrated graupel
   sfc:
     clevs: !!python/object/apply:numpy.arange [5, 91, 5]
@@ -1043,6 +1038,11 @@ vig: # Vertically-integrated graupel
     ticks: 0
     title: Max Vertically Integrated Graupel (over previous hour)
     unit: mm
+vil: # Vertically Integrated Liquid
+  sfc:
+    <<: *vert_int_liq
+    ncl_name: VAR_0_16_201_P0_L10_{grid}
+    title: Vertically Integrated Liquid
 vis: # Visibility
   sfc:
     clevs: [0.0625, 0.125, 0.25, 0.5, 1, 1.5, 2, 3, 4, 5, 10, 30, 50]

--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -246,7 +246,7 @@ cin: # Surface Convective Inhibition
     <<: *sfc_cin
     title: Surface CIN < -50
 cloudcover:
-  blcc: &cld_cover # PBL ... 1 km Cloud Cover
+  bndylay: &cld_cover # PBL ... 1 km Cloud Cover
     clevs: [2, 5, 10, 20, 30, 40, 50, 60, 70, 80, 90, 95]
     cmap: gist_ncar
     colors: cldcov_colors

--- a/image_lists/hrrr.yml
+++ b/image_lists/hrrr.yml
@@ -131,9 +131,8 @@ hourly:
     rh:
       - 2m
       - 850mb
+      - pw
       - ua
-    rhpw:
-      - sfc
     rvil:
       - sfc
     sfcp:
@@ -207,9 +206,9 @@ hourly:
       - sfc
     wspeed:
       - 10m
+      - 250mb
       - 80m
       - 850mb
-      - 250mb
       - max
       - mdn
       - mup

--- a/image_lists/hrrr.yml
+++ b/image_lists/hrrr.yml
@@ -1,38 +1,34 @@
 hourly:
   variables:
-    1hsm:
-      - sfc
     1hsnw:
       - sfc
+    1hsm:
+      - sfc
     1ref:
-      - sfc
+      - 1000m
     3hsm:
-      - sfc
-    6kshr:
-      - sfc
-    acfrzr:
       - sfc
     acfrozr:
       - sfc
-    acpcp:
-      - sfc
-    acsnod:
+    acfrzr:
       - sfc
     acp:
       - esbl
       - esblmn
       - sfc
+    acpcp:
+      - sfc
+    acsnod:
+      - sfc
     acsnw:
       - esbl
       - esblmn
       - sfc
-    blcc:
-      - sfc
     cape:
-      - sfc
       - mu
       - mul
       - mx90mb
+      - sfc
     ceil:
       - ua
     ceilexp:
@@ -42,6 +38,7 @@ hourly:
     cin:
       - sfc
     cloudcover:
+      - bndylay
       - high
       - low
       - mid
@@ -70,8 +67,8 @@ hourly:
     gust:
       - 10m
     hail:
-      - maxsfc
       - max
+      - maxsfc
     hailcast:
       - maxsfc
     hlcy:

--- a/image_lists/hrrr_subset.yml
+++ b/image_lists/hrrr_subset.yml
@@ -1,18 +1,26 @@
 hourly:
   variables:
+    1hsnw:
+      - sfc
     1ref:
       - 1000m
+    acfrozr:
+      - sfc
     acfrzr:
       - sfc
-    acfrozr:
+    acp:
       - sfc
     acpcp:
       - sfc
-    cape:
+    acsnod:
       - sfc
+    acsnw:
+      - sfc
+    cape:
       - mu
       - mul
       - mx90mb
+      - sfc
     ceil:
       - ua
     ceilexp:
@@ -22,6 +30,7 @@ hourly:
     cin:
       - sfc
     cloudcover:
+      - bndylay
       - high
       - low
       - mid
@@ -36,6 +45,8 @@ hourly:
       - 2m
     echotop:
       - sfc
+    flru:
+      - sfc
     G113bt:
       - sat
     G114bt:
@@ -47,8 +58,8 @@ hourly:
     gust:
       - 10m
     hail:
-      - maxsfc
       - max
+      - maxsfc
     hailcast:
       - maxsfc
     hlcy:
@@ -64,6 +75,8 @@ hourly:
       - mx25
       - sr01
       - sr03
+    hpbl:
+      - sfc
     lcl:
       - sfc
     lhtfl:
@@ -75,6 +88,9 @@ hourly:
       - sfc
     mref:
       - sfc
+    pres:
+      - msl
+      - sfc
     ptmp:
       - 2m
     pwtr:
@@ -85,12 +101,15 @@ hourly:
     rh:
       - 2m
       - 850mb
+      - pw
     rvil:
       - sfc
     shear:
       - 01km
       - 06km
     shtfl:
+      - sfc
+    snod:
       - sfc
     soilm:
       - sfc
@@ -145,3 +164,11 @@ hourly:
       - mx02
     weasd:
       - sfc
+    wspeed:
+      - 10m
+      - 80m
+      - 250mb
+      - 850mb
+      - max
+      - mdn
+      - mup

--- a/image_lists/hrrr_subset.yml
+++ b/image_lists/hrrr_subset.yml
@@ -1,5 +1,7 @@
 hourly:
   variables:
+    1ref:
+      - 1000m
     acfrzr:
       - sfc
     acfrozr:

--- a/image_lists/rtma.yml
+++ b/image_lists/rtma.yml
@@ -1,0 +1,185 @@
+hourly:
+  variables:
+    1hsnw:
+      - sfc
+    1hsm:
+      - sfc
+    1ref:
+      - 1000m
+    3hsm:
+      - sfc
+    acfrozr:
+      - sfc
+    acfrzr:
+      - sfc
+    acp:
+      - sfc
+    acpcp:
+      - sfc
+    acsnod:
+      - sfc
+    acsnw:
+      - sfc
+    cape:
+      - mu
+      - mul
+      - mx90mb
+      - sfc
+    ceil:
+      - ua
+    ceilexp:
+      - ua
+    ceilexp2:
+      - ua
+    cin:
+      - sfc
+    cloudcover:
+      - bndylay
+      - high
+      - low
+      - mid
+      - total
+    cpofp:
+      - sfc
+    cref:
+      - sfc
+    ctop:
+      - ua
+    dewp:
+      - 2m
+    echotop:
+      - sfc
+    flru:
+      - sfc
+    G113bt:
+      - sat
+    G114bt:
+      - sat
+    G123bt:
+      - sat
+    G124bt:
+      - sat
+    gust:
+      - 10m
+    hail:
+      - max
+      - maxsfc
+    hailcast:
+      - maxsfc
+    hlcy:
+      - in16
+      - in25
+      - mn02
+      - mn03
+      - mn16
+      - mnsfc
+      - mx02
+      - mx03
+      - mx16
+      - sr01
+      - sr03
+      - sfc
+    hpbl:
+      - sfc
+    lcl:
+      - sfc
+    lhtfl:
+      - sfc
+    li:
+      - sfc
+      - best
+    ltg3:
+      - sfc
+    mnvv:
+      - sfc
+    mref:
+      - sfc
+    ptmp:
+      - 2m
+    ptyp:
+      - sfc
+    pwtr:
+      - sfc
+    ref:
+      - m10
+      - maxm10
+    rh:
+      - 2m
+      - 850mb
+      - ua
+    rhpw:
+      - sfc
+    rvil:
+      - sfc
+    sfcp:
+      - sfc
+    shear:
+      - 01km
+      - 06km
+    shtfl:
+      - sfc
+    snod:
+      - sfc
+    soilm:
+      - sfc
+    soilt: &soilt_levs
+      - 0cm
+      - 1cm
+      - 4cm
+      - 10cm
+      - 30cm
+      - 60cm
+      - 1m
+      - 1.6m
+      - 3m
+    soilw: *soilt_levs
+    solar:
+      - sfc
+    ssrun:
+      - sfc
+    temp:
+      - 2ds
+      - 2m
+      - 500mb
+      - 700mb
+      - 850mb
+      - 925mb
+      - sfc
+    totp:
+      - sfc
+    ulwrf:
+      - sfc
+      - top
+    uswrf:
+      - sfc
+      - top
+    vbdsf:
+      - sfc
+    vddsf:
+      - sfc
+    vig:
+      - sfc
+    vil:
+      - sfc
+    vis:
+      - sfc
+    vort:
+      - 500mb
+    vvel:
+      - 700mb
+    vvort:
+      - mx01
+      - mx02
+    weasd:
+      - sfc
+    wspeed:
+      - 10m
+      - 80m
+      - 250mb
+      - 850mb
+      - max
+      - mdn
+      - mup
+    wpwr:
+      - 80m
+

--- a/image_lists/rtma.yml
+++ b/image_lists/rtma.yml
@@ -1,25 +1,11 @@
 hourly:
   variables:
-    1hsnw:
-      - sfc
-    1hsm:
-      - sfc
+#    1hsm:
+#      - sfc
     1ref:
       - 1000m
-    3hsm:
-      - sfc
-    acfrozr:
-      - sfc
-    acfrzr:
-      - sfc
-    acp:
-      - sfc
-    acpcp:
-      - sfc
-    acsnod:
-      - sfc
-    acsnw:
-      - sfc
+#    3hsm:
+#      - sfc
     cape:
       - mu
       - mul
@@ -29,12 +15,11 @@ hourly:
       - ua
     ceilexp:
       - ua
-    ceilexp2:
-      - ua
+#    ceilexp2:
+#      - ua
     cin:
       - sfc
     cloudcover:
-      - bndylay
       - high
       - low
       - mid
@@ -61,24 +46,11 @@ hourly:
       - sat
     gust:
       - 10m
-    hail:
-      - max
-      - maxsfc
-    hailcast:
-      - maxsfc
     hlcy:
       - in16
       - in25
-      - mn02
-      - mn03
-      - mn16
-      - mnsfc
-      - mx02
-      - mx03
-      - mx16
       - sr01
       - sr03
-      - sfc
     hpbl:
       - sfc
     lcl:
@@ -86,32 +58,31 @@ hourly:
     lhtfl:
       - sfc
     li:
-      - sfc
       - best
+      - sfc
     ltg3:
       - sfc
-    mnvv:
-      - sfc
+#    mnvv:
+#      - sfc
     mref:
+      - sfc
+    pres:
+      - msl
       - sfc
     ptmp:
       - 2m
-    ptyp:
-      - sfc
+#    ptyp:
+#      - sfc
     pwtr:
       - sfc
     ref:
       - m10
-      - maxm10
     rh:
       - 2m
       - 850mb
-      - ua
-    rhpw:
-      - sfc
+#      - ua
+      - pw
     rvil:
-      - sfc
-    sfcp:
       - sfc
     shear:
       - 01km
@@ -122,20 +93,7 @@ hourly:
       - sfc
     soilm:
       - sfc
-    soilt: &soilt_levs
-      - 0cm
-      - 1cm
-      - 4cm
-      - 10cm
-      - 30cm
-      - 60cm
-      - 1m
-      - 1.6m
-      - 3m
-    soilw: *soilt_levs
     solar:
-      - sfc
-    ssrun:
       - sfc
     temp:
       - 2ds
@@ -144,8 +102,6 @@ hourly:
       - 700mb
       - 850mb
       - 925mb
-      - sfc
-    totp:
       - sfc
     ulwrf:
       - sfc
@@ -157,8 +113,6 @@ hourly:
       - sfc
     vddsf:
       - sfc
-    vig:
-      - sfc
     vil:
       - sfc
     vis:
@@ -167,9 +121,6 @@ hourly:
       - 500mb
     vvel:
       - 700mb
-    vvort:
-      - mx01
-      - mx02
     weasd:
       - sfc
     wspeed:
@@ -177,9 +128,6 @@ hourly:
       - 80m
       - 250mb
       - 850mb
-      - max
-      - mdn
-      - mup
-    wpwr:
-      - 80m
+#    wpwr:
+#      - 80m
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -349,7 +349,7 @@ class TestDefaultSpecs():
         allowed_levels = [
             'agl',     # above ground level
             'best',    # Best
-            'blcc',    # boundary layer cld cover
+            'bndylay', # boundary layer cld cover
             'esbl',    # ???
             'esblmn',  # ???
             'high',    # high clouds


### PR DESCRIPTION
I created a first pass at the list of RTMA fields to be plotted. I tested in a real-time setting in my own workspace for both maps and skewts. 

The fields that are not currently available are commented out in the image list.

