### PR TITLE
add scale factor to hydrometeor legend

### DIFF
--- a/adb_graphics/figures/skewt.py
+++ b/adb_graphics/figures/skewt.py
@@ -139,17 +139,20 @@ class SkewTDiagram(grib.profileData):
                        f"{settings.get('units')}"
             lines.append(line)
 
+            label = f"{settings.get('label'):<7s}"
+            if scale != 1.0:
+                label = f"{settings.get('label'):<5s}(x{scale})"
             handles.append(mlines.Line2D([], [],
                                          color=settings.get('color'),
                                          fillstyle='none',
-                                         label=settings.get('label'),
+                                         label=label,
                                          linewidth=1.0,
                                          marker=settings.get('marker'),
                                          markersize=8,
                                          )
                           )
 
-        plt.legend(handles=handles, loc=[4.3, -0.8])
+        plt.legend(handles=handles, loc=[4.2, -0.8])
 
         contents = '\n'.join(lines)
         # Draw the vertically integrated amounts box


### PR DESCRIPTION
I added the scale factor for hydrometeors to the figure legend (it was already part of the vertical integration table).

Only a few lines in skewt.py changed.

Before and After:
<img width="796" alt="screen_shot_2021-03-31_at_5 18 51_pm" src="https://user-images.githubusercontent.com/56739562/113952929-eae98c00-97d3-11eb-9670-774e436293f8.png">
<img width="795" alt="Screen Shot 2021-04-07 at 7 02 29 PM" src="https://user-images.githubusercontent.com/56739562/113952936-ee7d1300-97d3-11eb-9ab1-6840e03729ee.png">
