### PR TITLE
Fix for plotting without zip files.

### DIFF
--- a/create_graphics.py
+++ b/create_graphics.py
@@ -556,14 +556,15 @@ def graphics_driver(cla):
                             )
 
             # Zip png files and remove the originals in a subprocess
-            for tile, zipf in zipfiles.items():
-                png_files = glob.glob(os.path.join(workdir, f'*_{tile}_*{fhr:02d}.png'))
-                zip_proc = Process(group=None,
-                                   target=create_zip,
-                                   args=(png_files, zipf),
-                                   )
-                zip_proc.start()
-                zip_proc.join()
+            if cla.zip_dir:
+                for tile, zipf in zipfiles.items():
+                    png_files = glob.glob(os.path.join(workdir, f'*_{tile}_*{fhr:02d}.png'))
+                    zip_proc = Process(group=None,
+                                       target=create_zip,
+                                       args=(png_files, zipf),
+                                       )
+                    zip_proc.start()
+                    zip_proc.join()
 
             # Keep track of last time we did something useful
             timer_end = time.time()


### PR DESCRIPTION
zipfiles is not defined when you don't provide a `-z` command line argument. Put this chunk of code inside an if statement to check for that.