### PR TITLE
Maps model name

### DIFF
--- a/adb_graphics/figures/maps.py
+++ b/adb_graphics/figures/maps.py
@@ -178,6 +178,7 @@ class Map():
 
 
 class DataMap():
+    #pylint: disable=too-many-arguments
 
     '''
     Class that combines the input data and the chosen map to plot both together.
@@ -192,12 +193,13 @@ class DataMap():
 
     '''
 
-    def __init__(self, field, map_, contour_fields=None, hatch_fields=None):
+    def __init__(self, field, map_, contour_fields=None, hatch_fields=None, model_name=None):
 
         self.field = field
         self.contour_fields = contour_fields
         self.hatch_fields = hatch_fields
         self.map = map_
+        self.model_name = model_name
 
 
     @staticmethod
@@ -394,7 +396,7 @@ class DataMap():
         contoured = ', '.join(contoured)
 
         # Analysis time (top) and forecast hour (bottom) on the left
-        plt.title(f"Analysis: {atime}\nFcst Hr: {f.fhr}", loc='left', fontsize=16)
+        plt.title(f"{self.model_name}: {atime}\nFcst Hr: {f.fhr}", loc='left', fontsize=16)
 
         # Atmospheric level and unit in the high center
         level, lev_unit = f.numeric_level(index_match=False)

--- a/adb_graphics/figures/skewt.py
+++ b/adb_graphics/figures/skewt.py
@@ -57,7 +57,7 @@ class SkewTDiagram(grib.profileData):
         self.model_name = kwargs.get('model_name', 'Analysis')
 
     def _add_hydrometeors(self, hydro_subplot):
-    # pylint: disable=too-many-locals, consider-using-enumerate
+    # pylint: disable=too-many-locals
         mixing_ratios = OrderedDict({
             'clwmr': {
                 'color': 'blue',
@@ -142,11 +142,11 @@ class SkewTDiagram(grib.profileData):
                                    markersize=6,
                                   )
                 layer = False
-                for i in range(len(profile)):
-                    if ((profile[i] > 0.0 and temp[i].magnitude < 32.0) and not layer):
+                for i, profile_lev in enumerate(profile):
+                    if ((profile_lev > 0.0 and temp[i].magnitude < 32.0) and not layer):
                         layer = True
                         p_base = pres[i].magnitude
-                    elif ((profile[i] <= 0.0 or temp[i].magnitude > 32.0) and layer):
+                    elif ((profile_lev <= 0.0 or temp[i].magnitude > 32.0) and layer):
                         # Shade the supercooled water depth
                         p_top = pres[i-1].magnitude
                         rect = plt.Rectangle((0, p_top), 100, (p_base-p_top),\

--- a/create_graphics.py
+++ b/create_graphics.py
@@ -424,6 +424,7 @@ def parallel_maps(cla, fhr, ds, level, model, spec, variable, workdir,
         contour_fields=contour_fields,
         hatch_fields=hatch_fields,
         map_=m,
+        model_name=cla.model_name,
         )
 
     # Draw the map

--- a/create_graphics.py
+++ b/create_graphics.py
@@ -243,7 +243,7 @@ def parse_args():
         )
     parser.add_argument(
         '-m',
-        default='hrrr',
+        default='Unnamed Experiment',
         dest='model_name',
         help='string to use in title of graphic.',
         type=str,


### PR DESCRIPTION
I added the model_name logic to the maps (already done for skewTs), and changed the default to "Unnamed Experiment".

This change also adds shaded hydrometeor regions and filled markers for supercooled layers.  

Passed pylint and pytest, with one pylint check disabled.

Sample skewT:
<img width="804" alt="Screen Shot 2021-04-11 at 7 24 00 PM" src="https://user-images.githubusercontent.com/56739562/114330453-02d84d00-9aff-11eb-8015-c00cd852b0f1.png">
